### PR TITLE
Expand types & fix schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   ],
   "scripts": {
     "lint": "tsc",
-    "schema:generate": "ts-json-schema-generator --tsconfig tsconfig.json --type Database -o src/schema.raw.json",
+    "schema:generate": "ts-json-schema-generator --tsconfig tsconfig.json --type Database -o src/schema.raw.json --expose all",
     "schema:postprocess": "node scripts/schema-postprocess.mjs",
     "schema:validate": "node scripts/schema-validate.mjs",
     "schema": "npm run schema:generate && npm run schema:postprocess && npm run schema:validate",

--- a/types/abstract/collection.ts
+++ b/types/abstract/collection.ts
@@ -5,6 +5,7 @@
  * @module abstract/collection
  */
 
+import type { Expand } from 'devtypes/types/util';
 import type { Property } from '@/abstract/property';
 
 
@@ -30,15 +31,24 @@ export type Distinct< T = unknown > = T;
 export type Group< T extends Record< string, Single< Property > | Distinct< unknown > > > = T;
 
 /**
- * Transforms a collection definition into its corresponding structure.
+ * Recursively transforms a collection definition into its corresponding structure.
+ * Handles Single, Group, Property, Distinct, and nested object types.
+ * 
+ * @template T - Collection definition
+ */
+export type CollectionValue< T > =
+    [ T ] extends [ Single< infer P > ] ? P :
+    [ T ] extends [ Group< infer G > ] ? { [ GK in keyof G ]: Collection< G[ GK ] > } :
+    [ T ] extends [ Property ] ? T :
+    [ T ] extends [ Distinct< infer D > ] ? Distinct< D > :
+    [ T ] extends [ object ] ? Expand< T > :
+    T;
+
+/**
+ * Main Collection type transforming a collection definition into its structure.
  * 
  * @template T - Collection definition
  */
 export type Collection< T > = {
-    [ K in keyof T ]:
-        T[ K ] extends Single< infer P > ? P :
-        T[ K ] extends Group< infer G > ? { [ GK in keyof G ]: Collection< G[ GK ] > } :
-        T[ K ] extends Distinct< infer D > ? Distinct< D > :
-        T[ K ] extends Property ? T[ K ] :
-        never;
+    [ K in keyof T ]: CollectionValue< T[ K ] >;
 };

--- a/types/abstract/form.ts
+++ b/types/abstract/form.ts
@@ -7,7 +7,7 @@
 
 import type { RequireFrom, StrictSubset } from 'devtypes/types/constraint';
 import type { DeepPartial } from 'devtypes/types/transform';
-import type { Brand } from 'devtypes/types/util';
+import type { Brand, Expand } from 'devtypes/types/util';
 import type { Collection, Distinct } from '@/abstract/collection';
 import type { FormType } from '@/enums/abstract';
 import type { CrystalStructure, Phase } from '@/enums/generic';
@@ -52,9 +52,10 @@ export interface FormFields {
  * 
  * @template C - Collection type for properties
  */
-export type AllotropeForm< C extends Collection< any > > =
+export type AllotropeForm< C extends Collection< any > > = Expand<
     BaseForm< FormType.ALLOTROPE | FormType.OTHER, C > &
-    FormFields;
+    FormFields
+>;
 
 /**
  * Form type for molecular forms.
@@ -62,9 +63,10 @@ export type AllotropeForm< C extends Collection< any > > =
  * 
  * @template C - Collection type for properties
  */
-export type MolecularForm< C extends Collection< any > > =
+export type MolecularForm< C extends Collection< any > > = Expand<
     BaseForm< FormType.MOLECULAR, C > &
-    RequireFrom< FormFields, 'formula' >;
+    RequireFrom< FormFields, 'formula' >
+>;
 
 /**
  * Form type for specific phases of substances.
@@ -72,9 +74,10 @@ export type MolecularForm< C extends Collection< any > > =
  * 
  * @template C - Collection type for properties
  */
-export type PhaseForm< C extends Collection< any > > =
+export type PhaseForm< C extends Collection< any > > = Expand<
     BaseForm< FormType.PHASE, C > &
-    RequireFrom< FormFields, 'phase' >;
+    RequireFrom< FormFields, 'phase' >
+>;
 
 /**
  * Form type for polymorphs and amorphous forms.
@@ -82,9 +85,10 @@ export type PhaseForm< C extends Collection< any > > =
  * 
  * @template C - Collection type for properties
  */
-export type PolymorphForm< C extends Collection< any > > =
+export type PolymorphForm< C extends Collection< any > > = Expand<
     BaseForm< FormType.POLYMORPH | FormType.AMORPHOUS, C > &
-    StrictSubset< FormFields, 'crystalStructure', 'pearsonSymbol' | 'spaceGroup' >;
+    StrictSubset< FormFields, 'crystalStructure', 'pearsonSymbol' | 'spaceGroup' >
+>;
 
 /** Branded form IDs used in other parts of the data model. */
 export type FormId = Brand< string, 'formId' >;

--- a/types/abstract/property.ts
+++ b/types/abstract/property.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Primitive } from 'devtypes/types/primitive';
+import type { Expand } from 'devtypes/types/util';
 import type { Conditions } from '@/abstract/condition';
 import type { RefId } from '@/abstract/reference';
 import type { PhysicalQuantity } from '@/abstract/unit';
@@ -41,7 +42,7 @@ export type PrimitiveProperty<
     P extends Primitive = Primitive,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.PrimitiveValue< P >;
+> = Expand< BaseProperty< C, T > & value.PrimitiveValue< P > >; 
 
 /**
  * Property wrapper for structure values (e.g. objects, arrays).
@@ -54,7 +55,7 @@ export type StructProperty<
     S extends value.StructType = value.StructType,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.StructValue< S >;
+> = Expand< BaseProperty< C, T > & value.StructValue< S > >; 
 
 /**
  * Property wrapper for single values.
@@ -67,7 +68,7 @@ export type SingleProperty<
     Q extends PhysicalQuantity = PhysicalQuantity,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.SingleValue< Q >;
+> = Expand< BaseProperty< C, T > & value.SingleValue< Q > >; 
 
 /**
  * Property wrapper for array values.
@@ -80,7 +81,7 @@ export type ArrayProperty<
     Q extends PhysicalQuantity = PhysicalQuantity,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.ArrayValue< Q >;
+> = Expand< BaseProperty< C, T > & value.ArrayValue< Q > >; 
 
 /**
  * Property wrapper for range values.
@@ -93,7 +94,7 @@ export type RangeProperty<
     Q extends PhysicalQuantity = PhysicalQuantity,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.RangeValue< Q >;
+> = Expand< BaseProperty< C, T > & value.RangeValue< Q > >; 
 
 /** Coupled property type definitions */
 
@@ -108,7 +109,7 @@ export type CoupledNumberProperty<
     Q extends PhysicalQuantity = PhysicalQuantity,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.CoupledNumberValue< Q >;
+> = Expand< BaseProperty< C, T > & value.CoupledNumberValue< Q > >; 
 
 /**
  * Property wrapper for coupled values.
@@ -125,7 +126,7 @@ export type CoupledProperty<
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive,
     S extends value.StructType = value.StructType
-> = BaseProperty< C, T > & value.CoupledValue< Q, P, S >;
+> = Expand< BaseProperty< C, T > & value.CoupledValue< Q, P, S > >; 
 
 /** Union property types */
 
@@ -140,7 +141,7 @@ export type NumberProperty<
     Q extends PhysicalQuantity = PhysicalQuantity,
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive
-> = BaseProperty< C, T > & value.NumberValue< Q >;
+> = Expand< BaseProperty< C, T > & value.NumberValue< Q > >; 
 
 /**
  * Union property wrapper for general values.
@@ -157,4 +158,4 @@ export type Property<
     C extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive,
     S extends value.StructType = value.StructType
-> = BaseProperty< C, T > & value.Value< Q, P, S >;
+> = Expand< BaseProperty< C, T > & value.Value< Q, P, S > >; 

--- a/types/abstract/reference.ts
+++ b/types/abstract/reference.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ExtractFrom, RequireAtLeastOne, RequireExactlyOne, StrictSubset } from 'devtypes/types/constraint';
-import type { Brand } from 'devtypes/types/util';
+import type { Brand, Expand } from 'devtypes/types/util';
 import type { ReferenceType } from '@/enums/abstract';
 
 
@@ -78,21 +78,23 @@ export interface BibTeXFields {
 
 /** Helper types for specific reference types */
 
-type Thesis< T extends ReferenceType.MASTERSTHESIS | ReferenceType.THESIS | ReferenceType.PHDTHESIS > =
+type Thesis< T extends ReferenceType.MASTERSTHESIS | ReferenceType.THESIS | ReferenceType.PHDTHESIS > = Expand<
     BaseReference< T > &
     StrictSubset<
         BibTeXFields,
         'author' | 'title' | 'school' | 'year',
         'type' | 'address' | 'month' | 'note'
-    >;
+    >
+>;
 
-type Conference< T extends ReferenceType.CONFERENCE | ReferenceType.INPROCEEDINGS > =
+type Conference< T extends ReferenceType.CONFERENCE | ReferenceType.INPROCEEDINGS > = Expand<
     BaseReference< T > &
     StrictSubset<
         BibTeXFields,
         'author' | 'title' | 'booktitle' | 'year',
         'editor' | 'volume' | 'number' | 'series' | 'pages' | 'address' | 'month' | 'organization' | 'publisher' | 'note'
-    >;
+    >
+>;
 
 /** Specific reference types */
 
@@ -101,39 +103,43 @@ type Conference< T extends ReferenceType.CONFERENCE | ReferenceType.INPROCEEDING
  * Includes required fields for author, title, journal, and year.
  * Optional fields include volume, number, pages, month, and note.
  */
-export type ArticleReference =
+export type ArticleReference = Expand<
     BaseReference< ReferenceType.ARTICLE > &
     StrictSubset<
         BibTeXFields,
         'author' | 'title' | 'journal' | 'year',
         'volume' | 'number' | 'pages' | 'month' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of a book reference.
  * Includes required fields for author/editor, title, publisher, and year.
  * Optional fields include volume, number, series, address, edition, month, note, and isbn.
  */
-export type BookReference =
+export type BookReference = Expand<
     BaseReference< ReferenceType.BOOK > &
     RequireExactlyOne< BibTeXFields, 'author' | 'editor' > &
     StrictSubset<
         BibTeXFields,
         'title' | 'publisher' | 'year',
         'volume' | 'number' | 'series' | 'address' | 'edition' | 'month' | 'note' | 'isbn'
-    >;
+    >
+>;
 
 /**
  * Type description of a booklet reference.
  * Includes required fields for title.
  * Optional fields include author, howpublished, address, month, year, and note.
  */
-export type BookletReference = BaseReference< ReferenceType.BOOKLET > &
+export type BookletReference = Expand<
+    BaseReference< ReferenceType.BOOKLET > &
     StrictSubset<
         BibTeXFields,
         'title',
         'author' | 'howpublished' | 'address' | 'month' | 'year' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of a conference reference.
@@ -147,7 +153,7 @@ export type ConferenceReference = Conference< ReferenceType.CONFERENCE >;
  * Includes required fields for author/editor, title, booktitle, chapter/pages, publisher, and year.
  * Optional fields include volume, number, series, type, address, edition, month, and note.
  */
-export type InbookReference =
+export type InbookReference = Expand<
     BaseReference< ReferenceType.INBOOK > &
     RequireExactlyOne< BibTeXFields, 'author' | 'editor' > &
     RequireAtLeastOne<
@@ -157,20 +163,22 @@ export type InbookReference =
             'volume' | 'number' | 'series' | 'type' | 'address' | 'edition' | 'month' | 'note'
         >,
         'chapter' | 'pages'
-    >;
+    >
+>;
 
 /**
  * Type description of an incollection reference.
  * Includes required fields for author, title, booktitle, publisher, and year.
  * Optional fields include editor, volume, number, series, type, chapter, pages, address, edition, month, and note.
  */
-export type IncollectionReference =
+export type IncollectionReference = Expand<
     BaseReference< ReferenceType.INCOLLECTION > &
     StrictSubset<
         BibTeXFields,
         'author' | 'title' | 'booktitle' | 'publisher' | 'year',
         'editor' | 'volume' | 'number' | 'series' | 'type' | 'chapter' | 'pages' | 'address' | 'edition' | 'month' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of an inproceedings reference.
@@ -184,13 +192,14 @@ export type InproceedingsReference = Conference< ReferenceType.INPROCEEDINGS >;
  * Includes required fields for title.
  * Optional fields include author, organization, address, edition, month, year, and note.
  */
-export type ManualReference =
+export type ManualReference = Expand<
     BaseReference< ReferenceType.MANUAL > &
     StrictSubset<
         BibTeXFields,
         'title',
         'author' | 'organization' | 'address' | 'edition' | 'month' | 'year' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of a mastersthesis reference.
@@ -210,12 +219,13 @@ export type ThesisReference = Thesis< ReferenceType.THESIS >;
  * Type description of a miscellaneous reference.
  * Optional fields include author, title, howpublished, month, year, and note.
  */
-export type MiscReference =
+export type MiscReference = Expand<
     BaseReference< ReferenceType.MISC > &
     ExtractFrom<
         BibTeXFields,
         'author' | 'title' | 'howpublished' | 'month' | 'year' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of a phdthesis reference.
@@ -229,39 +239,42 @@ export type PhdthesisReference = Thesis< ReferenceType.PHDTHESIS >;
  * Includes required fields for title and year.
  * Optional fields include editor, volume, number, series, address, month, organization, publisher, and note.
  */
-export type ProceedingsReference =
+export type ProceedingsReference = Expand<
     BaseReference< ReferenceType.PROCEEDINGS > &
     StrictSubset<
         BibTeXFields,
         'title' | 'year',
         'editor' | 'volume' | 'number' | 'series' | 'address' | 'month' | 'organization' | 'publisher' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of a techreport reference.
  * Includes required fields for author, title, institution, and year.
  * Optional fields include type, number, address, month, and note.
  */
-export type TechreportReference =
+export type TechreportReference = Expand<
     BaseReference< ReferenceType.TECHREPORT > &
     StrictSubset<
         BibTeXFields,
         'author' | 'title' | 'institution' | 'year',
         'type' | 'number' | 'address' | 'month' | 'note'
-    >;
+    >
+>;
 
 /**
  * Type description of an unpublished reference.
  * Includes required fields for author, title, and note.
  * Optional fields include month and year.
  */
-export type UnpublishedReference =
+export type UnpublishedReference = Expand<
     BaseReference< ReferenceType.UNPUBLISHED > &
     StrictSubset<
         BibTeXFields,
         'author' | 'title' | 'note',
         'month' | 'year'
-    >;
+    >
+>;
 
 /** Common types for the reference system */
 

--- a/types/abstract/uncertainty.ts
+++ b/types/abstract/uncertainty.ts
@@ -6,7 +6,7 @@
  */
 
 import type { RequireFrom } from 'devtypes/types/constraint';
-import type { Brand } from 'devtypes/types/util';
+import type { Brand, Expand } from 'devtypes/types/util';
 import type { UncertaintyType } from '@/enums/abstract';
 
 
@@ -44,25 +44,28 @@ export interface UncertaintyFields {
  * Type description of an absolute uncertainty.
  * Includes required absolute field.
  */
-export type AbsoluteUncertainty =
+export type AbsoluteUncertainty = Expand<
     BaseUncertainty< UncertaintyType.ABSOLUTE > &
-    RequireFrom< UncertaintyFields, 'absolute' >;
+    RequireFrom< UncertaintyFields, 'absolute' >
+>;
 
 /**
  * Type description of a relative uncertainty.
  * Includes required relative field.
  */
-export type RelativeUncertainty =
+export type RelativeUncertainty = Expand<
     BaseUncertainty< UncertaintyType.RELATIVE > &
-    RequireFrom< UncertaintyFields, 'relative' >;
+    RequireFrom< UncertaintyFields, 'relative' >
+>;
 
 /**
  * Type description of an asymmetrical uncertainty.
  * Includes required plus and minus fields.
  */
-export type AsymmetricalUncertainty =
+export type AsymmetricalUncertainty = Expand<
     BaseUncertainty< UncertaintyType.ASYMMETRICAL > &
-    RequireFrom< UncertaintyFields, 'plus' | 'minus' >;
+    RequireFrom< UncertaintyFields, 'plus' | 'minus' >
+>;
 
 /** Union type for all uncertainty types. */
 export type Uncertainty =

--- a/types/abstract/value.ts
+++ b/types/abstract/value.ts
@@ -7,7 +7,7 @@
 
 import type { RequireAtLeastOne, RequireExactlyOne, StrictSubset } from 'devtypes/types/constraint';
 import type { Primitive } from 'devtypes/types/primitive';
-import type { Brand } from 'devtypes/types/util';
+import type { Brand, Expand } from 'devtypes/types/util';
 import type { Uncertainty } from '@/abstract/uncertainty';
 import type { PhysicalQuantity, UnitId } from '@/abstract/unit';
 import type { ValueType, ValueConfidence } from '@/enums/abstract';
@@ -64,9 +64,10 @@ export interface ValueFields<
  * 
  * @template T - Primitive type
  */
-export type PrimitiveValue< T extends Primitive = Primitive > =
+export type PrimitiveValue< T extends Primitive = Primitive > = Expand<
     BaseValue< ValueType.PRIMITIVE > &
-    RequireExactlyOne< ValueFields< never, T >, 'value' | 'values' >;
+    RequireExactlyOne< ValueFields< never, T >, 'value' | 'values' >
+>; 
 
 /** Struct key type. */
 export type StructKey = string | number;
@@ -80,9 +81,10 @@ export type StructType = Record< StructKey, any >;
  * 
  * @template T - Struct type
  */
-export type StructValue< T extends StructType = StructType > =
+export type StructValue< T extends StructType = StructType > = Expand<
     BaseValue< ValueType.STRUCT > &
-    RequireAtLeastOne< ValueFields< never, never, T >, 'struct' >; 
+    RequireAtLeastOne< ValueFields< never, never, T >, 'struct' >
+>; 
 
 /**
  * Type description of a single numeric value.
@@ -90,9 +92,10 @@ export type StructValue< T extends StructType = StructType > =
  * 
  * @template Q - Physical quantity type
  */
-export type SingleValue< Q extends PhysicalQuantity = PhysicalQuantity > =
+export type SingleValue< Q extends PhysicalQuantity = PhysicalQuantity > = Expand<
     BaseValue< ValueType.SINGLE > &
-    StrictSubset< ValueFields< Q, number >, 'value', 'unit' >;
+    StrictSubset< ValueFields< Q, number >, 'value', 'unit' >
+>;
 
 /**
  * Type description of an numeric array value.
@@ -100,9 +103,10 @@ export type SingleValue< Q extends PhysicalQuantity = PhysicalQuantity > =
  * 
  * @template Q - Physical quantity type
  */
-export type ArrayValue< Q extends PhysicalQuantity = PhysicalQuantity > =
+export type ArrayValue< Q extends PhysicalQuantity = PhysicalQuantity > = Expand<
     BaseValue< ValueType.ARRAY > &
-    StrictSubset< ValueFields< Q, number >, 'values', 'unit' >;
+    StrictSubset< ValueFields< Q, number >, 'values', 'unit' >
+>;
 
 /**
  * Type description of a numeric range value.
@@ -110,9 +114,10 @@ export type ArrayValue< Q extends PhysicalQuantity = PhysicalQuantity > =
  * 
  * @template Q - Physical quantity type
  */
-export type RangeValue< Q extends PhysicalQuantity = PhysicalQuantity > =
+export type RangeValue< Q extends PhysicalQuantity = PhysicalQuantity > = Expand<
     BaseValue< ValueType.RANGE > &
-    StrictSubset< ValueFields< Q, number >, 'range', 'value' | 'unit' >;
+    StrictSubset< ValueFields< Q, number >, 'range', 'value' | 'unit' >
+>;
 
 /** Coupled value type definitions */
 
@@ -121,7 +126,7 @@ export type RangeValue< Q extends PhysicalQuantity = PhysicalQuantity > =
  * 
  * @template Q - Physical quantity type
  */
-export type CoupledNumberValue< Q extends PhysicalQuantity = PhysicalQuantity > =
+export type CoupledNumberValue< Q extends PhysicalQuantity = PhysicalQuantity > = Expand<
     BaseValue< ValueType.COUPLED > & {
         properties: RequireAtLeastOne< {
             [ K in Q ]?:
@@ -129,7 +134,8 @@ export type CoupledNumberValue< Q extends PhysicalQuantity = PhysicalQuantity > 
                 | ArrayValue< K >
                 | RangeValue< K >;
         } >;
-    };
+    }
+>;
 
 /**
  * Type description of a coupled value with generic primitives.
@@ -142,7 +148,7 @@ export type CoupledValue<
     Q extends PhysicalQuantity = PhysicalQuantity,
     T extends Primitive = Primitive,
     S extends StructType = StructType
-> =
+> = Expand<
     BaseValue< ValueType.COUPLED > & {
         properties: RequireAtLeastOne< {
             [ K in Q ]?:
@@ -152,7 +158,8 @@ export type CoupledValue<
                 | ArrayValue< K >
                 | RangeValue< K >;
         } >;
-    };
+    }
+>;
 
 /** Union value types */
 

--- a/types/collections/chemistry.ts
+++ b/types/collections/chemistry.ts
@@ -8,7 +8,7 @@
 import type { Collection, Group, Single } from '@/abstract/collection';
 import type { NumberProperty, PrimitiveProperty, StructProperty } from '@/abstract/property';
 import type { AcidBaseCharacter, BondType, HSAB, Hybridization, LewisAcidity, LewisBasicity, OxideCharacter } from '@/enums/chemistry';
-import { CrystalStructure } from '@/enums/generic';
+import type { CrystalStructure } from '@/enums/generic';
 
 
 /**

--- a/types/entities/compound.ts
+++ b/types/entities/compound.ts
@@ -5,6 +5,7 @@
  * @module entities/compound
  */
 
+import type { Expand } from 'devtypes/types/util';
 import type { Collection, Distinct, Single } from '@/abstract/collection';
 import type { FormCollection } from '@/abstract/form';
 import type { PrimitiveProperty } from '@/abstract/property';
@@ -93,7 +94,7 @@ export type SingleCompound = Collection< {
  * optional specialized forms such as polymorphs, solvates, or phase variants.
  */
 export type Compound = Collection< {
-    [ key: string ]: MetaData & SingleCompound & {
+    [ key: string ]: Expand< MetaData & SingleCompound & {
         forms?: FormCollection< SingleCompound >;
-    };
+    } >;
 } >;

--- a/types/entities/element.ts
+++ b/types/entities/element.ts
@@ -5,6 +5,7 @@
  * @module entities/element
  */
 
+import type { Expand } from 'devtypes/types/util';
 import type { Collection, Distinct, Single } from '@/abstract/collection';
 import type { FormCollection } from '@/abstract/form';
 import type { PrimitiveProperty } from '@/abstract/property';
@@ -81,7 +82,7 @@ export type SingleElement = Collection< {
  * Forms are alternative representations or variations of the element data.
  */
 export type Element = Collection< {
-    [ K in ElementSymbol ]: MetaData & SingleElement & {
+    [ K in ElementSymbol ]: Expand< MetaData & SingleElement & {
         forms?: FormCollection< SingleElement >;
-    };
+    } >;
 } >;

--- a/types/entities/mineral.ts
+++ b/types/entities/mineral.ts
@@ -9,6 +9,7 @@
  * @module entities/mineral
  */
 
+import type { Expand } from 'devtypes/types/util';
 import type { Collection, Distinct, Group, Single } from '@/abstract/collection';
 import type { FormCollection } from '@/abstract/form';
 import type { PrimitiveProperty, StructProperty } from '@/abstract/property';
@@ -105,9 +106,9 @@ export type SingleMineral = Collection< {
     descriptive: DescriptiveCollection;
     classification: MineralClassification;
     composition: MineralComposition;
-    physics?: PhysicsCollection & {
+    physics?: Expand< PhysicsCollection & {
         identification?: IdentificationGroup;
-    };
+    } >;
     chemistry?: ChemistryCollection;
     properties?: Distinct< MineralProperty[] >;
     safety?: SafetyCollection;
@@ -121,7 +122,7 @@ export type SingleMineral = Collection< {
  * optional specialized forms.
  */
 export type Mineral = Collection< {
-    [ key: string ]: MetaData & SingleMineral & {
+    [ key: string ]: Expand< MetaData & SingleMineral & {
         forms?: FormCollection< SingleMineral >;
-    };
+    } >;
 } >;

--- a/types/entities/nuclide.ts
+++ b/types/entities/nuclide.ts
@@ -8,6 +8,7 @@
  * @module entities/nuclide
  */
 
+import type { Expand } from 'devtypes/types/util';
 import type { Collection, Distinct, Group, Single } from '@/abstract/collection';
 import type { NumberProperty, PrimitiveProperty, StructProperty } from '@/abstract/property';
 import type { NumberValue } from '@/abstract/value';
@@ -141,7 +142,7 @@ export type SingleNuclide = Collection< {
  */
 export type Nuclides = Collection< {
     [ K in ElementSymbol ]?: {
-        [ N in NuclideIdentifier ]?: MetaData & SingleNuclide;
+        [ N in NuclideIdentifier ]?: Expand< MetaData & SingleNuclide >;
     };
 } >;
 


### PR DESCRIPTION
Currently, types are not being unfolded correctly, and the resulting JSON schema is incomplete. This issue results due to incorrect handling of connected types using the `&` operator.

We'll address this problem by stabilizing the collection wrapper and, most importantly, using `Expand<T>` from the [devtypes package](https://npmjs.com/devtypes). This type flattens intersections for clearer hover tooltips and autocompletion. It does not change the type itself but improves editor readability.