### PR TITLE
Improve properties

### DIFF
--- a/types/abstract/form.ts
+++ b/types/abstract/form.ts
@@ -10,7 +10,7 @@ import type { DeepPartial } from 'devtypes/types/transform';
 import type { Brand, Expand } from 'devtypes/types/util';
 import type { Collection, Distinct } from '@/abstract/collection';
 import type { FormType } from '@/enums/abstract';
-import type { CrystalStructure, Phase } from '@/enums/generic';
+import type { CrystalSystem, Phase } from '@/enums/generic';
 
 
 /**
@@ -32,14 +32,14 @@ export type BaseForm< T extends FormType, C extends Collection< any > > = Brand<
  * 
  * @param formula - Chemical formula of the form
  * @param phase - Phase of the substance (solid, liquid, gas, plasma)
- * @param crystalStructure - Crystal structure type
+ * @param crystalSystem - Crystal structure type
  * @param pearsonSymbol - Pearson symbol notation
  * @param spaceGroup - Space group notation
  */
 export interface FormFields {
     formula?: Distinct< string >;
     phase?: Distinct< Phase >;
-    crystalStructure?: Distinct< CrystalStructure >;
+    crystalSystem?: Distinct< CrystalSystem >;
     pearsonSymbol?: Distinct< string >;
     spaceGroup?: Distinct< string >;
 }
@@ -87,7 +87,7 @@ export type PhaseForm< C extends Collection< any > > = Expand<
  */
 export type PolymorphForm< C extends Collection< any > > = Expand<
     BaseForm< FormType.POLYMORPH | FormType.AMORPHOUS, C > &
-    StrictSubset< FormFields, 'crystalStructure', 'pearsonSymbol' | 'spaceGroup' >
+    StrictSubset< FormFields, 'crystalSystem', 'pearsonSymbol' | 'spaceGroup' >
 >;
 
 /** Branded form IDs used in other parts of the data model. */

--- a/types/collections/atomics.ts
+++ b/types/collections/atomics.ts
@@ -7,7 +7,7 @@
 
 import type { Collection, Group, Single } from '@/abstract/collection';
 import type { ArrayProperty, NumberProperty, PrimitiveProperty, StructProperty } from '@/abstract/property';
-import type { NMRGroup } from '@/collections/generic';
+import type { NMRGroup } from '@/collections/nuclear';
 import type { ShellModel } from '@/enums/element';
 
 

--- a/types/collections/chemistry.ts
+++ b/types/collections/chemistry.ts
@@ -8,7 +8,7 @@
 import type { Collection, Group, Single } from '@/abstract/collection';
 import type { NumberProperty, PrimitiveProperty, StructProperty } from '@/abstract/property';
 import type { AcidBaseCharacter, BondType, HSAB, Hybridization, LewisAcidity, LewisBasicity, OxideCharacter } from '@/enums/chemistry';
-import type { CrystalSystem } from '@/enums/generic';
+import type { CrystalSystem, Goldschmidt } from '@/enums/generic';
 
 
 /**
@@ -41,6 +41,7 @@ export type ChemistryCollection = Collection< {
         isoelectricPoint?: Single< PrimitiveProperty< number > >;
         lewisAcidity?: Single< PrimitiveProperty< LewisAcidity > >;
         lewisBasicity?: Single< PrimitiveProperty< LewisBasicity > >;
+        goldschmidt?: Single< PrimitiveProperty< Goldschmidt > >;
         hsab?: Single< PrimitiveProperty< HSAB > >;
     } >;
 

--- a/types/collections/chemistry.ts
+++ b/types/collections/chemistry.ts
@@ -8,7 +8,7 @@
 import type { Collection, Group, Single } from '@/abstract/collection';
 import type { NumberProperty, PrimitiveProperty, StructProperty } from '@/abstract/property';
 import type { AcidBaseCharacter, BondType, HSAB, Hybridization, LewisAcidity, LewisBasicity, OxideCharacter } from '@/enums/chemistry';
-import type { CrystalStructure } from '@/enums/generic';
+import type { CrystalSystem } from '@/enums/generic';
 
 
 /**
@@ -60,21 +60,23 @@ export type ChemistryCollection = Collection< {
 
     // Crystallographic properties
     crystal?: Group< {
-        crystalStructure?: Single< PrimitiveProperty< CrystalStructure > >;
+        crystalSystem?: Single< PrimitiveProperty< CrystalSystem > >;
         crystalClass?: Single< PrimitiveProperty< string > >;
-        spaceGroup?: Single< PrimitiveProperty< string > >;
-        spaceGroupNumber?: Single< PrimitiveProperty< number > >;
-        spaceGroupSymbol?: Single< PrimitiveProperty< string > >;
+        spaceGroup?: Single< StructProperty< {
+            number: number;
+            symbol: string;
+        } > >;
+        schoenfliesSymbol?: Single< PrimitiveProperty< string > >;
         pearsonSymbol?: Single< PrimitiveProperty< string > >;
-        formulaUnitsZ?: Single< PrimitiveProperty< number > >;
-        latticeConstant?: StructProperty< {
+        latticeConstant?: Single< StructProperty< {
             a?: number;
             b?: number;
             c?: number;
             alpha?: number;
             beta?: number;
             gamma?: number;
-        } >;
+            Z?: number;
+        } > >;
         twinning?: Single< PrimitiveProperty< string > >;
         habit?: Single< PrimitiveProperty< string > >;
         faces?: Single< PrimitiveProperty< string > >;

--- a/types/collections/composition.ts
+++ b/types/collections/composition.ts
@@ -5,9 +5,7 @@
  * @module collections/composition
  */
 
-import type { Collection, Distinct, Group, Single } from '@/abstract/collection';
-import type { NumberProperty, PrimitiveProperty } from '@/abstract/property';
-import type { ComponentRole } from '@/enums/compound';
+import type { Collection, Distinct, Group } from '@/abstract/collection';
 import type { ElementSymbol } from '@/enums/element';
 
 
@@ -16,35 +14,19 @@ import type { ElementSymbol } from '@/enums/element';
  * 
  * @param element - Distinct chemical symbol of the element
  * @param amount - Distinct stoichiometric amount or number of atoms
- * @param frequency - Optional occurrence frequency or probability
- * @param role - Role of the component (e.g., cation, anion, impurity)
- * @param massFraction - Optional mass fraction of the element
- * @param atomicFraction - Optional atomic fraction of the element
- * @param charge - Optional formal charge of the component
  */
 export type CompositionComponent = Group< {
     element: Distinct< ElementSymbol >;
     amount: Distinct< number >;
-    frequency?: Single< PrimitiveProperty< number > >;
-    role?: Single< PrimitiveProperty< ComponentRole > >;
-    massFraction?: Single< NumberProperty< 'massFraction' > >;
-    atomicFraction?: Single< NumberProperty< 'massFraction' > >;
-    charge?: Single< PrimitiveProperty< number > >;
 } >;
 
 /**
  * Collection for compositional properties.
  * 
+ * @param formula - Chemical formula
  * @param components - List of components that make up the substance
- * @param formula - Distinct chemical formula
- * @param empiricalFormula - Distinct empirical formula
- * @param structuralFormula - Distinct structural formula (e.g. for minerals or complex compounds)
- * @param charge - Overall formal charge
  */
 export type CompositionCollection = Collection< {
-    components: CompositionComponent[];
     formula: Distinct< string >;
-    empiricalFormula?: Distinct< string >;
-    structuralFormula?: Distinct< string >;
-    charge?: Single< PrimitiveProperty< number > >;
+    components: CompositionComponent[];
 } >;

--- a/types/collections/composition.ts
+++ b/types/collections/composition.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Collection, Distinct, Group, Single } from '@/abstract/collection';
-import type { PrimitiveProperty } from '@/abstract/property';
+import type { NumberProperty, PrimitiveProperty } from '@/abstract/property';
 import type { ComponentRole } from '@/enums/compound';
 import type { ElementSymbol } from '@/enums/element';
 
@@ -27,8 +27,8 @@ export type CompositionComponent = Group< {
     amount: Distinct< number >;
     frequency?: Single< PrimitiveProperty< number > >;
     role?: Single< PrimitiveProperty< ComponentRole > >;
-    massFraction?: Single< PrimitiveProperty< number > >;
-    atomicFraction?: Single< PrimitiveProperty< number > >;
+    massFraction?: Single< NumberProperty< 'massFraction' > >;
+    atomicFraction?: Single< NumberProperty< 'massFraction' > >;
     charge?: Single< PrimitiveProperty< number > >;
 } >;
 
@@ -36,15 +36,15 @@ export type CompositionComponent = Group< {
  * Collection for compositional properties.
  * 
  * @param components - List of components that make up the substance
- * @param formula - Chemical formula
- * @param empiricalFormula - Empirical formula
- * @param structuralFormula - Structural formula (e.g. for minerals or complex compounds)
+ * @param formula - Distinct chemical formula
+ * @param empiricalFormula - Distinct empirical formula
+ * @param structuralFormula - Distinct structural formula (e.g. for minerals or complex compounds)
  * @param charge - Overall formal charge
  */
 export type CompositionCollection = Collection< {
     components: CompositionComponent[];
-    formula: Single< PrimitiveProperty< string > >;
-    empiricalFormula?: Single< PrimitiveProperty< string > >;
-    structuralFormula?: Single< PrimitiveProperty< string > >;
+    formula: Distinct< string >;
+    empiricalFormula?: Distinct< string >;
+    structuralFormula?: Distinct< string >;
     charge?: Single< PrimitiveProperty< number > >;
 } >;

--- a/types/collections/composition.ts
+++ b/types/collections/composition.ts
@@ -15,7 +15,7 @@ import type { ElementSymbol } from '@/enums/element';
  * Defines the structure for a single component of a chemical substance or mineral.
  * 
  * @param element - Distinct chemical symbol of the element
- * @param amount - Stoichiometric amount or number of atoms
+ * @param amount - Distinct stoichiometric amount or number of atoms
  * @param frequency - Optional occurrence frequency or probability
  * @param role - Role of the component (e.g., cation, anion, impurity)
  * @param massFraction - Optional mass fraction of the element
@@ -24,7 +24,7 @@ import type { ElementSymbol } from '@/enums/element';
  */
 export type CompositionComponent = Group< {
     element: Distinct< ElementSymbol >;
-    amount: Single< PrimitiveProperty< number > >;
+    amount: Distinct< number >;
     frequency?: Single< PrimitiveProperty< number > >;
     role?: Single< PrimitiveProperty< ComponentRole > >;
     massFraction?: Single< PrimitiveProperty< number > >;

--- a/types/collections/descriptive.ts
+++ b/types/collections/descriptive.ts
@@ -20,6 +20,7 @@ import type { LangCode } from '@/enums/generic';
  * @param names - Names in different languages
  * @param description - Descriptions in different languages
  * @param appearance - Appearance descriptions in different languages
+ * @param odor - Odor descriptions in different languages
  * @param abundance - Natural abundance information group
  * @param discovery - Discovery information group
  * @param media - Media information group
@@ -32,6 +33,7 @@ export type DescriptiveCollection = Collection< {
     names: LangGroup< LangCode.ENGLISH | LangCode.LATIN >;
     description?: LangGroup;
     appearance?: LangGroup;
+    odor?: LangGroup;
     abundance?: AbundanceGroup;
     discovery?: DiscoveryGroup;
     media?: MediaGroup;

--- a/types/collections/generic.ts
+++ b/types/collections/generic.ts
@@ -7,7 +7,7 @@ import type { Expand } from 'devtypes/types/util';
 import type { Distinct, Group, Single } from '@/abstract/collection';
 import type { NumberProperty, PrimitiveProperty } from '@/abstract/property';
 import type { RefId } from '@/abstract/reference';
-import type { D3Format, ImageFormat, LangCode } from '@/enums/generic';
+import type { D3Format, ImageFormat, LangCode, NaturalOccurrence } from '@/enums/generic';
 
 
 /**
@@ -39,6 +39,7 @@ export type LangGroup< L extends LangCode = LangCode.ENGLISH, T = string > = Gro
  * AbundanceGroup
  * Natural abundance data for elements, minerals, isotopes, etc.
  * 
+ * @param naturalOccurrence - Natural occurrence type
  * @param universeAbundance - Abundance in the universe
  * @param solarSystemAbundance - Abundance in the solar system
  * @param sunAbundance - Abundance in the sun
@@ -53,6 +54,9 @@ export type LangGroup< L extends LangCode = LangCode.ENGLISH, T = string > = Gro
  * @param oreAbundance - Abundance in ores
  */
 export type AbundanceGroup = Group< {
+    
+    // Natural occurrence
+    naturalOccurrence?: Single< PrimitiveProperty< NaturalOccurrence > >;
 
     // Cosmic abundance
     universeAbundance?: Single< NumberProperty< 'quantity' > >;

--- a/types/collections/generic.ts
+++ b/types/collections/generic.ts
@@ -151,27 +151,3 @@ export type WeblinksGroup = Group< {
     }[] >;
     wiki?: LangGroup;
 } >;
-
-/**
- * NMRGroup
- * Nuclear Magnetic Resonance properties for nuclides.
- * 
- * @param spin - Nuclear spin quantum number
- * @param gyromagneticRatio - Gyromagnetic ratio of the nuclide
- * @param magneticMoment - Magnetic moment of the nuclide
- * @param larmorPrecession - Larmor precession frequency
- * @param sensitivity - Relative sensitivity of the nuclide in NMR
- * @param quadrupoleMoment - Quadrupole moment of the nuclide
- * @param referenceField - Reference magnetic field strength for NMR measurements
- * @param chemicalShiftReference - Chemical shift reference information
- */
-export type NMRGroup = Group< {
-    spin?: Single< PrimitiveProperty< number > >;
-    gyromagneticRatio?: Single< NumberProperty< 'magneticMoment' > >;
-    magneticMoment?: Single< NumberProperty< 'magneticMoment' > >;
-    larmorPrecession?: Single< NumberProperty< 'frequency' > >;
-    sensitivity?: Single< PrimitiveProperty< number > >;
-    quadrupoleMoment?: Single< NumberProperty< 'quantity' > >;
-    referenceField?: Single< NumberProperty< 'magneticFieldStrength' > >;
-    chemicalShiftReference?: Single< PrimitiveProperty< string > >;
-} >;

--- a/types/collections/nuclear.ts
+++ b/types/collections/nuclear.ts
@@ -20,7 +20,7 @@ import type { NumberProperty, PrimitiveProperty } from '@/abstract/property';
  * @param sensitivity - Relative sensitivity of the nuclide in NMR
  * @param quadrupoleMoment - Quadrupole moment of the nuclide
  * @param referenceField - Reference magnetic field strength for NMR measurements
- * @param chemicalShiftReference - Chemical shift reference information
+ * @param chemicalShiftReference - Chemical shift reference
  */
 export type NMRGroup = Group< {
     spin?: Single< PrimitiveProperty< number > >;

--- a/types/collections/nuclear.ts
+++ b/types/collections/nuclear.ts
@@ -1,0 +1,67 @@
+/**
+ * Nuclear Collection
+ * Defines a set of nuclear properties for nuclides.
+ * 
+ * @module collections/nuclear
+ */
+
+import type { Collection, Group, Single } from '@/abstract/collection';
+import type { NumberProperty, PrimitiveProperty } from '@/abstract/property';
+
+
+/**
+ * NMRGroup
+ * Nuclear Magnetic Resonance properties for nuclides.
+ * 
+ * @param spin - Nuclear spin quantum number
+ * @param gyromagneticRatio - Gyromagnetic ratio of the nuclide
+ * @param magneticMoment - Magnetic moment of the nuclide
+ * @param larmorPrecession - Larmor precession frequency
+ * @param sensitivity - Relative sensitivity of the nuclide in NMR
+ * @param quadrupoleMoment - Quadrupole moment of the nuclide
+ * @param referenceField - Reference magnetic field strength for NMR measurements
+ * @param chemicalShiftReference - Chemical shift reference information
+ */
+export type NMRGroup = Group< {
+    spin?: Single< PrimitiveProperty< number > >;
+    gyromagneticRatio?: Single< NumberProperty< 'magneticMoment' > >;
+    magneticMoment?: Single< NumberProperty< 'magneticMoment' > >;
+    larmorPrecession?: Single< NumberProperty< 'frequency' > >;
+    sensitivity?: Single< PrimitiveProperty< number > >;
+    quadrupoleMoment?: Single< NumberProperty< 'quantity' > >;
+    referenceField?: Single< NumberProperty< 'magneticFieldStrength' > >;
+    chemicalShiftReference?: Single< PrimitiveProperty< string > >;
+} >;
+
+/**
+ * Collection for nuclear properties of nuclides.
+ * 
+ * @param atomicMass - Atomic mass of the nuclide
+ * @param massExcess - Mass excess of the nuclide
+ * @param bindingEnergyPerNucleon - Binding energy per nucleon
+ * @param neutronSeparationEnergy - Neutron separation energy
+ * @param protonSeparationEnergy - Proton separation energy
+ * @param nuclearChargeRadius - Nuclear charge radius
+ * @param excitationEnergy - Excitation energy levels
+ * @param isomericTransitionEnergy - Isomeric transition energy for metastable states
+ * @param qValue - Q value for electron capture
+ * @param crossSection - Cross section data
+ * @param nrm - NMR properties collection
+ */
+export type NuclearCollection = Collection< {
+    atomicMass?: Single< NumberProperty< 'mass' > >;
+    massExcess?: Single< NumberProperty< 'energy' > >;
+    bindingEnergyPerNucleon?: Single< NumberProperty< 'energy' > >;
+    neutronSeparationEnergy?: Single< NumberProperty< 'energy' > >;
+    protonSeparationEnergy?: Single< NumberProperty< 'energy' > >;
+    nuclearChargeRadius?: Single< NumberProperty< 'length' > >;
+    excitationEnergy?: Single< NumberProperty< 'energy' > >;
+    isomericTransitionEnergy?: Single< NumberProperty< 'energy' > >;
+    qValue?: Single< NumberProperty< 'energy' > >;
+    crossSection?: Group< {
+        thermalNeutronCapture?: Single< NumberProperty< 'area' > >;
+        resonanceIntegral?: Single< NumberProperty< 'area' > >;
+        fission?: Single< NumberProperty< 'area' > >;
+    } >;
+    nrm?: NMRGroup;
+} >;

--- a/types/collections/physics.ts
+++ b/types/collections/physics.ts
@@ -7,7 +7,7 @@
 
 import type { Collection, Group, Single } from '@/abstract/collection';
 import type { CoupledNumberProperty, NumberProperty, PrimitiveProperty } from '@/abstract/property';
-import type { Phase } from '@/enums/generic';
+import type { Phase, Superconductivity } from '@/enums/generic';
 import type { Luster, MagneticOrdering, OpticalRotation } from '@/enums/physics';
 
 
@@ -96,6 +96,7 @@ export type PhysicsCollection = Collection< {
         electricConductivity?: Single< NumberProperty< 'electricConductivity' > >;
         electricResistivity?: Single< NumberProperty< 'electricResistivity' > >;
         temperatureCoefficient?: Single< NumberProperty< 'tempCoefficient' > >;
+        superconductivity?: Single< PrimitiveProperty< Superconductivity > >;
         superconductingPoint?: Single< NumberProperty< 'temperature' > >;
         bandGap?: Single< NumberProperty< 'energy' > >;
         dielectricConstant?: Single< PrimitiveProperty< number > >;

--- a/types/entities/compound.ts
+++ b/types/entities/compound.ts
@@ -27,12 +27,14 @@ import type { Phase } from '@/enums/generic';
  * @param family - Optional family classification of the compound (e.g., alcohols, ketones)
  * @param phase - Standard phase at room temperature
  * @param radioactive - Whether the compound is radioactive
+ * @param properties - List of compound properties
  */
 export type CompoundClassification = Collection< {
     category: Distinct< CompoundCategory >;
     family?: Distinct< string >;
     phase: Distinct< Phase >;
     radioactive: Distinct< boolean >;
+    properties: Distinct< CompoundProperty[] >;
 } >;
 
 /** Main compound entity */
@@ -45,7 +47,6 @@ export type CompoundClassification = Collection< {
  * @param composition - Compositional collections for the compound
  * @param physics - Optional physics properties collection
  * @param chemistry - Optional chemistry properties collection
- * @param properties - Distinct list of compound properties
  * @param safety - Optional safety properties collection
  */
 export type SingleCompound = Collection< {
@@ -54,7 +55,6 @@ export type SingleCompound = Collection< {
     composition: CompositionCollection;
     physics?: PhysicsCollection;
     chemistry?: ChemistryCollection;
-    properties?: Distinct< CompoundProperty[] >;
     safety?: SafetyCollection;
 } >;
 

--- a/types/entities/compound.ts
+++ b/types/entities/compound.ts
@@ -5,18 +5,17 @@
  * @module entities/compound
  */
 
-import type { Expand } from 'devtypes/types/util';
-import type { Collection, Distinct, Single } from '@/abstract/collection';
+import type { Brand, Expand } from 'devtypes/types/util';
+import type { Collection, Distinct } from '@/abstract/collection';
 import type { FormCollection } from '@/abstract/form';
-import type { PrimitiveProperty } from '@/abstract/property';
 import type { ChemistryCollection } from '@/collections/chemistry';
 import type { CompositionCollection } from '@/collections/composition';
 import type { DescriptiveCollection } from '@/collections/descriptive';
 import type { MetaData } from '@/collections/generic';
 import type { PhysicsCollection } from '@/collections/physics';
 import type { SafetyCollection } from '@/collections/safety';
-import type { CompoundCategory, CompoundPolarity, CompoundProperty } from '@/enums/compound';
-import type { NaturalOccurrence, Phase } from '@/enums/generic';
+import type { CompoundCategory, CompoundProperty } from '@/enums/compound';
+import type { Phase } from '@/enums/generic';
 
 
 /** Compound collections */
@@ -26,41 +25,14 @@ import type { NaturalOccurrence, Phase } from '@/enums/generic';
  * 
  * @param category - Category of the compound (e.g., organic, inorganic)
  * @param family - Optional family classification of the compound (e.g., alcohols, ketones)
- * @param radioactive - Whether the compound is radioactive
  * @param phase - Standard phase at room temperature
- * @param naturalOccurrence - Natural occurrence type
+ * @param radioactive - Whether the compound is radioactive
  */
 export type CompoundClassification = Collection< {
-    category: Single< PrimitiveProperty< CompoundCategory > >;
-    family?: Single< PrimitiveProperty< string > >;
-    radioactive: Single< PrimitiveProperty< boolean > >;
-    phase?: Single< PrimitiveProperty< Phase > >;
-    naturalOccurrence?: Single< PrimitiveProperty< NaturalOccurrence > >;
-} >;
-
-/**
- * Collections for compositional properties of chemical compounds.
- * 
- * @param molecularFormula - Molecular formula of the compound
- * @param simplifiedFormula - Simplified formula of the compound
- * @param multiplicity - Multiplicity of the compound (e.g., for radicals)
- * @param aromatic - Whether the compound is aromatic
- * @param polarity - Polarity of the compound (nonpolar, polar, amphipathic)
- * @param stoichiometry - Stoichiometric information for the compound
- * @param repeatUnit - Repeat unit for polymers
- * @param hydration - Number of water molecules in hydrates
- * @param functionalGroups - List of functional groups present in the compound
- */
-export type CompoundComposition = Collection< CompositionCollection & {
-    molecularFormula?: Single< PrimitiveProperty< string > >;
-    simplifiedFormula?: Single< PrimitiveProperty< string > >;
-    multiplicity?: Single< PrimitiveProperty< number > >;
-    aromatic?: Single< PrimitiveProperty< boolean > >;
-    polarity?: Single< PrimitiveProperty< CompoundPolarity > >;
-    stoichiometry?: Single< PrimitiveProperty< string > >;
-    repeatUnit?: Single< PrimitiveProperty< string > >;
-    hydration?: Single< PrimitiveProperty< number > >;
-    functionalGroups?: Single< PrimitiveProperty< string > >;
+    category: Distinct< CompoundCategory >;
+    family?: Distinct< string >;
+    phase: Distinct< Phase >;
+    radioactive: Distinct< boolean >;
 } >;
 
 /** Main compound entity */
@@ -79,7 +51,7 @@ export type CompoundComposition = Collection< CompositionCollection & {
 export type SingleCompound = Collection< {
     descriptive: DescriptiveCollection;
     classification: CompoundClassification;
-    composition: CompoundComposition;
+    composition: CompositionCollection;
     physics?: PhysicsCollection;
     chemistry?: ChemistryCollection;
     properties?: Distinct< CompoundProperty[] >;
@@ -87,17 +59,20 @@ export type SingleCompound = Collection< {
 } >;
 
 /** Type description for a single compound entity. */
-export type CompoundEntity = Expand< MetaData & SingleCompound & {
+export type Compound = Expand< MetaData & SingleCompound & {
     forms?: FormCollection< SingleCompound >; 
 } >;
 
+/** Branded unique identifier for indexing compounds */
+export type CompoundID = Brand< string, 'compoundID' >;
+
 /**
- * Entity type for chemical compounds, indexed by a unique identifier.
+ * Collection of chemical compounds, indexed by a unique identifier.
  * 
  * Each compound entry includes metadata, descriptive content, classification,
  * composition details, chemical and physical properties, safety data, and
  * optional specialized forms such as polymorphs, solvates, or phase variants.
  */
-export type Compound = Collection< {
-    [ key: string ]: CompoundEntity;
+export type CompoundCollection = Collection< {
+    [ key: CompoundID ]: Compound;
 } >;

--- a/types/entities/element.ts
+++ b/types/entities/element.ts
@@ -32,6 +32,7 @@ import type { Phase, PTColumn, PTPeriod } from '@/enums/generic';
  * @param phase - Standard phase at room temperature
  * @param set - Set classification of the element
  * @param radioactive - Whether the element is radioactive
+ * @param properties - List of element properties
  */
 export type ElementClassification = Collection< {
     symbol: Distinct< string >;
@@ -43,6 +44,7 @@ export type ElementClassification = Collection< {
     phase: Distinct< Phase >;
     set: Distinct< ElementSet >;
     radioactive: Distinct< boolean >;
+    properties: Distinct< ElementProperty[] >;
 } >;
 
 /** Main element entity */
@@ -55,7 +57,6 @@ export type ElementClassification = Collection< {
  * @param physics - Physics properties collection
  * @param chemistry - Chemistry properties collection
  * @param atomics - Atomics properties collection
- * @param properties - Distinct list of element properties
  * @param safety - Safety properties collection
  */
 export type SingleElement = Collection< {
@@ -64,7 +65,6 @@ export type SingleElement = Collection< {
     physics?: PhysicsCollection;
     chemistry?: ChemistryCollection;
     atomics?: AtomicsCollection;
-    properties?: Distinct< ElementProperty[] >;
     safety?: SafetyCollection;
 } >;
 

--- a/types/entities/element.ts
+++ b/types/entities/element.ts
@@ -6,9 +6,8 @@
  */
 
 import type { Expand } from 'devtypes/types/util';
-import type { Collection, Distinct, Single } from '@/abstract/collection';
+import type { Collection, Distinct } from '@/abstract/collection';
 import type { FormCollection } from '@/abstract/form';
-import type { PrimitiveProperty } from '@/abstract/property';
 import type { AtomicsCollection } from '@/collections/atomics';
 import type { ChemistryCollection } from '@/collections/chemistry';
 import type { DescriptiveCollection } from '@/collections/descriptive';
@@ -16,7 +15,7 @@ import type { MetaData } from '@/collections/generic';
 import type { PhysicsCollection } from '@/collections/physics';
 import type { SafetyCollection } from '@/collections/safety';
 import type { ElementBlock, ElementGroup, ElementProperty, ElementSet, ElementSymbol } from '@/enums/element';
-import type { Goldschmidt, NaturalOccurrence, Phase, PTColumn, PTPeriod, Superconductivity } from '@/enums/generic';
+import type { Phase, PTColumn, PTPeriod } from '@/enums/generic';
 
 
 /** Element collections */
@@ -24,18 +23,15 @@ import type { Goldschmidt, NaturalOccurrence, Phase, PTColumn, PTPeriod, Superco
 /**
  * Collection for classification properties of elements.
  * 
- * @param symbol - Distinct chemical symbol of the element
- * @param atomicNumber - Distinct atomic number of the element
- * @param block - Distinct block of the periodic table
- * @param group - Distinct group of the periodic table
- * @param column - Distinct column number in the periodic table
- * @param period - Distinct period number in the periodic table
+ * @param symbol - Chemical symbol of the element
+ * @param atomicNumber - Atomic number of the element
+ * @param block - Block of the periodic table
+ * @param group - Group of the periodic table
+ * @param column - Column number in the periodic table
+ * @param period - Period number in the periodic table
  * @param phase - Standard phase at room temperature
- * @param set - Distinct set classification of the element
+ * @param set - Set classification of the element
  * @param radioactive - Whether the element is radioactive
- * @param naturalOccurrence - Natural occurrence type
- * @param goldschmidt - Goldschmidt classification
- * @param superconductivity - Superconductivity type
  */
 export type ElementClassification = Collection< {
     symbol: Distinct< string >;
@@ -46,10 +42,7 @@ export type ElementClassification = Collection< {
     period: Distinct< PTPeriod >;
     phase: Distinct< Phase >;
     set: Distinct< ElementSet >;
-    radioactive: Single< PrimitiveProperty< boolean > >;
-    naturalOccurrence?: Single< PrimitiveProperty< NaturalOccurrence > >;
-    goldschmidt?: Single< PrimitiveProperty< Goldschmidt > >;
-    superconductivity?: Single< PrimitiveProperty< Superconductivity > >;
+    radioactive: Distinct< boolean >;
 } >;
 
 /** Main element entity */
@@ -76,16 +69,16 @@ export type SingleElement = Collection< {
 } >;
 
 /** Type description for a single element entity. */
-export type ElementEntity = Expand< MetaData & SingleElement & {
+export type Element = Expand< MetaData & SingleElement & {
     forms?: FormCollection< SingleElement >;
 } >;
 
 /**
- * Entity type for all elements, indexed by their symbol.
+ * Collection of all elements, indexed by their symbol.
  * 
  * This includes metadata, collections for a single element, and optional forms.
  * Forms are alternative representations or variations of the element data.
  */
-export type Element = Collection< {
-    [ K in ElementSymbol ]: ElementEntity;
+export type ElementCollection = Collection< {
+    [ K in ElementSymbol ]: Element;
 } >;

--- a/types/entities/nuclide.ts
+++ b/types/entities/nuclide.ts
@@ -13,7 +13,8 @@ import type { Collection, Distinct, Group, Single } from '@/abstract/collection'
 import type { NumberProperty, PrimitiveProperty, StructProperty } from '@/abstract/property';
 import type { NumberValue } from '@/abstract/value';
 import type { DescriptiveCollection } from '@/collections/descriptive';
-import type { MetaData, NMRGroup } from '@/collections/generic';
+import type { MetaData } from '@/collections/generic';
+import type { NuclearCollection } from '@/collections/nuclear';
 import type { ElementSymbol } from '@/enums/element';
 import type { DecayMode, NuclideParity, NuclideProperty, NuclideStability, NuclideState, RadiationType } from '@/enums/nuclide';
 
@@ -46,39 +47,6 @@ export type NuclideClassification = Collection< {
     parity?: Single< PrimitiveProperty< NuclideParity > >;
     spinParity?: Single< PrimitiveProperty< string > >;
     isomericLevel?: Single< PrimitiveProperty< string > >;
-} >;
-
-/**
- * Collection for nuclear properties of nuclides.
- * 
- * @param atomicMass - Atomic mass of the nuclide
- * @param massExcess - Mass excess of the nuclide
- * @param bindingEnergyPerNucleon - Binding energy per nucleon
- * @param neutronSeparationEnergy - Neutron separation energy
- * @param protonSeparationEnergy - Proton separation energy
- * @param nuclearChargeRadius - Nuclear charge radius
- * @param excitationEnergy - Excitation energy levels
- * @param isomericTransitionEnergy - Isomeric transition energy for metastable states
- * @param qValue - Q value for electron capture
- * @param crossSection - Cross section data
- * @param nrm - NMR properties collection
- */
-export type NuclearCollection = Collection< {
-    atomicMass?: Single< NumberProperty< 'mass' > >;
-    massExcess?: Single< NumberProperty< 'energy' > >;
-    bindingEnergyPerNucleon?: Single< NumberProperty< 'energy' > >;
-    neutronSeparationEnergy?: Single< NumberProperty< 'energy' > >;
-    protonSeparationEnergy?: Single< NumberProperty< 'energy' > >;
-    nuclearChargeRadius?: Single< NumberProperty< 'length' > >;
-    excitationEnergy?: Single< NumberProperty< 'energy' > >;
-    isomericTransitionEnergy?: Single< NumberProperty< 'energy' > >;
-    qValue?: Single< NumberProperty< 'energy' > >;
-    crossSection?: Group< {
-        thermalNeutronCapture?: Single< NumberProperty< 'area' > >;
-        resonanceIntegral?: Single< NumberProperty< 'area' > >;
-        fission?: Single< NumberProperty< 'area' > >;
-    } >;
-    nrm?: NMRGroup;
 } >;
 
 /**

--- a/types/enums/generic.ts
+++ b/types/enums/generic.ts
@@ -33,34 +33,14 @@ export enum Phase {
 
 /** Enumeration of periodic table columns. */
 export enum PTColumn {
-    COL_1 = 1,
-    COL_2 = 2,
-    COL_3 = 3,
-    COL_4 = 4,
-    COL_5 = 5,
-    COL_6 = 6,
-    COL_7 = 7,
-    COL_8 = 8,
-    COL_9 = 9,
-    COL_10 = 10,
-    COL_11 = 11,
-    COL_12 = 12,
-    COL_13 = 13,
-    COL_14 = 14,
-    COL_15 = 15,
-    COL_16 = 16,
-    COL_17 = 17,
-    COL_18 = 18
+    COL_1 = 1, COL_2 = 2, COL_3 = 3, COL_4 = 4, COL_5 = 5, COL_6 = 6, COL_7 = 7, COL_8 = 8,
+    COL_9 = 9, COL_10 = 10, COL_11 = 11, COL_12 = 12, COL_13 = 13, COL_14 = 14, COL_15 = 15,
+    COL_16 = 16, COL_17 = 17, COL_18 = 18
 };
 
 /** Enumeration of periodic table periods. */
 export enum PTPeriod {
-    PERIOD_1 = 1,
-    PERIOD_2 = 2,
-    PERIOD_3 = 3,
-    PERIOD_4 = 4,
-    PERIOD_5 = 5,
-    PERIOD_6 = 6,
+    PERIOD_1 = 1, PERIOD_2 = 2, PERIOD_3 = 3, PERIOD_4 = 4, PERIOD_5 = 5, PERIOD_6 = 6,
     PERIOD_7 = 7
 };
 
@@ -99,7 +79,7 @@ export enum Superconductivity {
 };
 
 /** Enumeration of crystal structures. */
-export enum CrystalStructure {
+export enum CrystalSystem {
     /** Hexagonal crystal system */
     HEXAGONAL = 'hexagonal',
     /** Hexagonal close-packed structure */

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,7 +13,7 @@
 import type { ReferenceCollection } from '@/abstract/reference';
 import type { UnitCollection } from '@/abstract/unit';
 
-import type { Compound } from '@/entities/compound';
+import type { CompoundCollection } from '@/entities/compound';
 import type { ElementCollection } from '@/entities/element';
 import type { Mineral } from '@/entities/mineral';
 import type { Nuclide } from '@/entities/nuclide';
@@ -30,7 +30,7 @@ import type { Nuclide } from '@/entities/nuclide';
  */
 export type Database = {
     elements: ElementCollection;
-    compounds: Compound;
+    compounds: CompoundCollection;
     minerals: Mineral;
     nuclides: Nuclide;
     references: ReferenceCollection;

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,7 +14,7 @@ import type { ReferenceCollection } from '@/abstract/reference';
 import type { UnitCollection } from '@/abstract/unit';
 
 import type { Compound } from '@/entities/compound';
-import type { Element } from '@/entities/element';
+import type { ElementCollection } from '@/entities/element';
 import type { Mineral } from '@/entities/mineral';
 import type { Nuclide } from '@/entities/nuclide';
 
@@ -29,7 +29,7 @@ import type { Nuclide } from '@/entities/nuclide';
  * @param units - Collection of measurement units
  */
 export type Database = {
-    elements: Element;
+    elements: ElementCollection;
     compounds: Compound;
     minerals: Mineral;
     nuclides: Nuclide;


### PR DESCRIPTION
Recheck all properties, particularly classification properties specified in entities. Currently, `Property` and `Distinct` types get used all mixed up. There should be a consistent approach.